### PR TITLE
CRAB-55114: Add .whitesource file to enable scanning of repo

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,3 @@
+{
+  "settingsInheritedFrom": "seeq12/whitesource-config@main"
+}


### PR DESCRIPTION
When this file is added, it inherits settings from [this repo](https://github.com/seeq12/whitesource-config/tree/main) where there is a github action to use the "Mend for GitHub Integration App" to scan the repo and upload results to Mend.